### PR TITLE
add support for rtsps

### DIFF
--- a/aiortsp/rtsp/connection.py
+++ b/aiortsp/rtsp/connection.py
@@ -34,7 +34,7 @@ class RTSPConnection(asyncio.Protocol):
 
     """
 
-    def __init__(self, host, port, username=None, password=None, accept_auth=None, logger=None, timeout=10):
+    def __init__(self, host, port, username=None, password=None, accept_auth=None, logger=None, ssl=None, timeout=10):
         self.host = host
         self.port = port
         self.username = username
@@ -42,6 +42,7 @@ class RTSPConnection(asyncio.Protocol):
         self.accept_auth = [auth.lower() for auth in accept_auth] if accept_auth else ['basic', 'digest']
         self.default_timeout = timeout
         self.logger = logger or _logger
+        self.ssl = ssl
 
         self._transport = None
         self.result = asyncio.Future()
@@ -67,7 +68,7 @@ class RTSPConnection(asyncio.Protocol):
         loop = asyncio.get_event_loop()
         try:
             await asyncio.wait_for(
-                loop.create_connection(lambda: self, self.host, self.port),
+                loop.create_connection(lambda: self, self.host, self.port, ssl = self.ssl),
                 self.default_timeout
             )
         except (asyncio.TimeoutError, OSError) as to:

--- a/aiortsp/rtsp/sdp.py
+++ b/aiortsp/rtsp/sdp.py
@@ -212,7 +212,7 @@ class SDP(dict):
         if not ctrl or ctrl == '*':
             return base
 
-        if ctrl.startswith('rtsp://'):
+        if ctrl.startswith('rtsp://') or ctrl.startswith('rtsps://'):
             return ctrl
 
         if not ctrl.startswith('/') and not base.endswith('/'):

--- a/aiortsp/rtsp/session.py
+++ b/aiortsp/rtsp/session.py
@@ -25,8 +25,11 @@ def sanitize_rtsp_url(url: str) -> str:
     Sanitize an RTSP url, removing exotic scheme and authentication.
     """
     p_url = urlparse(url)
+    scheme = p_url.scheme
+    if scheme != 'rtsp' and scheme != 'rtsps':
+        scheme = 'rtsp'
     return p_url._replace(
-        scheme='rtsp',
+        scheme=scheme,
         netloc=f'{p_url.hostname}' if p_url.port is None else f'{p_url.hostname}:{p_url.port}'
     ).geturl()
 

--- a/aiortsp/transport/__init__.py
+++ b/aiortsp/transport/__init__.py
@@ -20,7 +20,8 @@ def transport_for_scheme(scheme: str) -> Type[RTPTransport]:
     """Return transport type based on scheme"""
     transport_class = {
         'rtsp': UDPTransport,
-        'rtspt': TCPTransport
+        'rtspt': TCPTransport,
+        'rtsps': TCPTransport
     }.get(scheme)
 
     if not transport_class:


### PR DESCRIPTION
RTSPS is just RTSP, but wrapped in TLS.  Some RTSPS applications require a special SSL context (for instance, one that doesn't verify certificates), so we plumb a SSL context option in as well.  For instance, to connect to a Bambu Lab X1 Carbon printer, try:

```python
import asyncio
import logging
import sys
import ssl
from aiortsp.rtsp.reader import RTSPReader

logging.getLogger().setLevel(logging.DEBUG)
handler = logging.StreamHandler(sys.stdout)
logging.getLogger().addHandler(handler)

async def main():
    ssl_ctx = ssl.create_default_context()
    ssl_ctx.check_hostname = False
    ssl_ctx.verify_mode = ssl.CERT_NONE
    # Open a reader (which means RTSP connection, then media session)
    async with RTSPReader('rtsps://bblp:password@10.1.10.50/streaming/live/1', log_level=10, run_loop=True, ssl=ssl_ctx) as reader:
        # Iterate on RTP packets
        async for pkt in reader.iter_packets():
            print('PKT', pkt.cc, pkt.m, pkt.pt, pkt.seq, pkt.ts, pkt.ssrc, len(pkt.data))
    print("... all done...")

asyncio.run(main())
```