### PR TITLE
Add a lightweight/minimal implementation of audio, not multiplexed.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ This repository follows changelog_.
 We try to stick to **Semantic versioning**.
 
 
+[1.4.1] - 2025-09-22
+====================
+
+Added
+-----
+* Add audio support to the library (as separate media, not multiplexed).
+* Add an example to show how to receive audio.
+
+
 [1.4.0] - 2024-09-27
 ====================
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ One could easily decode using `OpenCV <https://pypi.org/project/opencv-python/>`
 or `PyAV <https://pypi.org/project/av/>`_, or not at all depending on the intended
 use.
 
-See ``examples`` for how to use the lib internals, butfor quick usage:
+See ``examples`` for how to use the lib internals, but for quick usage:
 
 .. code-block:: python3
 
@@ -30,6 +30,12 @@ See ``examples`` for how to use the lib internals, butfor quick usage:
     async def main():
         # Open a reader (which means RTSP connection, then media session)
         async with RTSPReader('rtsp://cam/video.sdp') as reader:
+            # Iterate on RTP packets
+            async for pkt in reader.iter_packets():
+                print('PKT', pkt.seq, pkt.pt, len(pkt))
+
+        # Open a reader for audio
+        async with RTSPReader('rtsp://cam/audio.sdp', media_type='audio') as reader:
             # Iterate on RTP packets
             async for pkt in reader.iter_packets():
                 print('PKT', pkt.seq, pkt.pt, len(pkt))

--- a/aiortsp/__version__.py
+++ b/aiortsp/__version__.py
@@ -2,4 +2,4 @@
 aiortsp version
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/aiortsp/rtsp/reader.py
+++ b/aiortsp/rtsp/reader.py
@@ -29,8 +29,9 @@ class RTSPReader(RTPTransportClient):
 
     def __init__(
             self, media_url: str, timeout=10, log_level=20,
-            ssl = None,
-            run_loop=False, **_
+            ssl=None,
+            run_loop=False,
+            media_type="video", **_
     ):
         self.media_url = media_url
         self.logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class RTSPReader(RTPTransportClient):
         self.timeout = timeout
         self.run_loop = run_loop
         self.ssl = ssl
+        self._media_type = media_type
         self.queue: 'asyncio.Queue[RTP]' = asyncio.Queue()
         self._runner = None
         self.connection: Optional[RTSPConnection] = None
@@ -50,12 +52,13 @@ class RTSPReader(RTPTransportClient):
         if self.payload_type and self.payload_type != rtp.pt:
             return
 
+        rtp.media_type = self._media_type
         self.queue.put_nowait(rtp)
 
     def on_ready(self, connection: RTSPConnection, transport: RTPTransport, session: RTSPMediaSession):
         """Handler on ready to play stream, for sub classes to do their initialisation"""
         if session.sdp:
-            self.payload_type = session.sdp.media_payload_type()
+            self.payload_type = session.sdp.media_payload_type(self._media_type)
         transport.subscribe(self)
         self.connection = connection
         self.transport = transport
@@ -105,7 +108,7 @@ class RTSPReader(RTPTransportClient):
 
             transport_class = transport_for_scheme(p_url.scheme)
             async with transport_class(conn, logger=self.logger, timeout=self.timeout) as transport:
-                async with RTSPMediaSession(conn, self.media_url, transport=transport, logger=self.logger) as sess:
+                async with RTSPMediaSession(conn, self.media_url, transport=transport, media_type=self._media_type, logger=self.logger) as sess:
 
                     self.on_ready(conn, transport, sess)
 

--- a/aiortsp/rtsp/session.py
+++ b/aiortsp/rtsp/session.py
@@ -81,14 +81,16 @@ class RTSPMediaSession:
             'Accept': 'application/sdp'
         })
 
-        if 'content-base' in resp.headers:
-            self.media_url = resp.headers['content-base']
-            self.logger.info('using base url: %s', self.media_url)
+        if resp.status == 200:
+            if 'content-base' in resp.headers:
+                self.media_url = resp.headers['content-base']
+                self.logger.info('using base url: %s', self.media_url)
 
-        self.logger.debug('received SDP:\n%s', resp.content)
-        self.sdp = SDP(resp.content)
-        self.logger.debug('parsed SDP:\n%s', json.dumps(self.sdp, indent=2))
-
+            self.logger.debug('received SDP:\n%s', resp.content)
+            self.sdp = SDP(resp.content)
+            self.logger.debug('parsed SDP:\n%s', json.dumps(self.sdp, indent=2))
+        else:
+            self.logger.error(f'Failed to get SDP: {resp.status} {resp.msg}')
         setup_url = self.sdp.setup_url(self.media_url, media_type=self.media_type)
         self.logger.info('setting up using URL: %s', setup_url)
 

--- a/aiortsp/rtsp/session.py
+++ b/aiortsp/rtsp/session.py
@@ -81,16 +81,14 @@ class RTSPMediaSession:
             'Accept': 'application/sdp'
         })
 
-        if resp.status == 200:
-            if 'content-base' in resp.headers:
-                self.media_url = resp.headers['content-base']
-                self.logger.info('using base url: %s', self.media_url)
+        if 'content-base' in resp.headers:
+            self.media_url = resp.headers['content-base']
+            self.logger.info('using base url: %s', self.media_url)
 
-            self.logger.debug('received SDP:\n%s', resp.content)
-            self.sdp = SDP(resp.content)
-            self.logger.debug('parsed SDP:\n%s', json.dumps(self.sdp, indent=2))
-        else:
-            self.logger.error(f'Failed to get SDP: {resp.status} {resp.msg}')
+        self.logger.debug('received SDP:\n%s', resp.content)
+        self.sdp = SDP(resp.content)
+        self.logger.debug('parsed SDP:\n%s', json.dumps(self.sdp, indent=2))
+
         setup_url = self.sdp.setup_url(self.media_url, media_type=self.media_type)
         self.logger.info('setting up using URL: %s', setup_url)
 

--- a/examples/audio.py
+++ b/examples/audio.py
@@ -1,0 +1,41 @@
+"""Audio example using the RTSPReader"""
+
+import asyncio
+import contextlib
+import logging
+import sys
+
+from aiortsp.rtsp.reader import RTSPReader
+
+logging.getLogger().setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+logging.getLogger().addHandler(handler)
+
+
+async def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-l", "--logging", type=int, default=20, help="Log level")
+    parser.add_argument(
+        "--media", type=str, default="audio", help="Media type to request"
+    )
+    parser.add_argument("url", help="RTSP url")
+    args = parser.parse_args()
+
+    # Open a reader (which means RTSP connection, then media session)
+    async with RTSPReader(
+        args.url, log_level=args.logging, run_loop=True, media_type=args.media
+    ) as reader:
+        # Iterate on RTP packets
+        async for pkt in reader.iter_packets():
+            logging.info(
+                "AUDIO PKT %s",
+                (pkt.cc, pkt.m, pkt.pt, pkt.seq, pkt.ts, pkt.ssrc, len(pkt.data)),
+            )
+    logging.info("... all done...")
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(main())


### PR DESCRIPTION
## Description

This PR provides a super minimal implementation to allow audio reception through this library. The included example simply receives the `audio_packets`, from which one would need to extract the `au_packet` depending on the codec and then process or play it as desired.  

More comprehensive PRs like **#20** and **#13** are in progress for full multiplexed A/V, so... I completely understand if this does not get merged.

## Example

1.  Run the new example script, pointing it to an RTSP stream that includes an audio track.

    ```bash
    python examples/audio.py "rtsp://your-camera-ip:port/stream?audioenable=on"
    ```

2.  Confirm that the console displays the connection logs followed by a continuous stream of `AUDIO PKT` messages, similar to the output below. This indicates that audio packets are being successfully received.

```
python examples/audio.py "rtsp://192.168.1.60:8086/?camera=world&audioenable=on"
Using selector: KqueueSelector
try loading stream rtsp://192.168.1.60:8086/?camera=world&audioenable=on
connected!
UDP Transport ready, will use ports 63760-63761
session options: {'SETUP', 'TEARDOWN', 'PLAY', 'PAUSE', 'DESCRIBE'}
using base url: rtsp://192.168.1.60:8086/
setting up using URL: rtsp://192.168.1.60:8086/trackID=0
server RTP/RTCP ports: 51489-52925
stream correctly setup: <Response status=200 msg="OK"" headers={'server': 'Pupil Invisible RTSP Server', 'cseq': '3', 'content-length': '0', 'transport': 'RTP/AVP/UDP;unicast;destination=192.168.1.139;client_port=63760-63761;server_port=51489-52925;ssrc=24934f8e;mode=play', 'session': '1185d20035702ca', 'cache-control': 'no-cache'} content-length=0>
session id: 1185d20035702ca, timeout: 60, keep_alive: 54
sending warmup RTP uplink traffic
sending warmup RTCP uplink traffic
playing stream...
start playing rtsp://192.168.1.60:8086/ at time `now` and speed `1`...
received RTCP from ('192.168.1.60', 52925)
AUDIO PKT (0, 1, 97, 31, 35039492, 613633934, 516)
AUDIO PKT (0, 1, 97, 32, 35040516, 613633934, 516)
AUDIO PKT (0, 1, 97, 33, 35041540, 613633934, 516)
AUDIO PKT (0, 1, 97, 34, 35042564, 613633934, 547)
AUDIO PKT (0, 1, 97, 35, 35043588, 613633934, 485)
```

## Related Issues

* **Related**: #13, #20. This PR provides an audio-only implementation, which is a subset of the functionality targeted in the A/V multiplexing PRs.

##  Notes

* For a more complete example showing how to decode and handle audio and video from an specific camera, see this [video_and_audio.py example](https://github.com/mikelgg93/aiortsp/blob/master/examples/video_and_audio.py).
* This PR was created from a feature branch instead of `master` to isolate unrelated code formatting changes caused by a *Format on Save* setting.